### PR TITLE
Fix RT#116825: install in 'perl' for perl < 5.12

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,10 @@ format = %-7v %{yyyy-MM-dd}d
 
 [@Basic]
 
+; RT116825: install in the right location depending on $]
+[DualLife]
+:version = 0.06
+
 [InstallGuide]
 [MetaJSON]
 


### PR DESCRIPTION
Fix for [RT#116825](https://rt.cpan.org/Ticket/Display.html?id=116825): Because site_perl is after 'perl' with perl 5.6 to 5.10.1.
