### PR TITLE
Add timelocal_modern and timegm_modern variants as optional exports

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,10 @@
   treated as 1970, but starting in 2020 this would be treated as 2070
   instead. Reported by Bernhard M. Wiedemann. RT #124787.
 
+- Added timelocal_modern and timegm_modern variants as optional exports. These
+  versions do not munge years at all. They treat the year value that they are
+  given exactly as-is.
+
 
 1.25     2016-11-17
 

--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,7 @@ copyright_year = 1997
 [@DROLSKY]
 dist = Time-Local
 stopwords = Christiansen
+stopwords = google
 stopwords = nocheck
 use_github_issues = 1
 DROLSKY::WeaverConfig.include_donations_pod = 0

--- a/lib/Time/Local.pm
+++ b/lib/Time/Local.pm
@@ -63,9 +63,9 @@ if ( $^O eq 'vos' ) {
     $Epoc = _daygm( 0, 0, 0, 1, 0, 70, 4, 0 );
 }
 elsif ( $^O eq 'MacOS' ) {
-    $MaxDay *= 2 if $^O eq 'MacOS';    # time_t unsigned ... quick hack?
-          # MacOS time() is seconds since 1 Jan 1904, localtime
-          # so we need to calculate an offset to apply later
+    $MaxDay *= 2;    # time_t unsigned ... quick hack?
+                     # MacOS time() is seconds since 1 Jan 1904, localtime
+                     # so we need to calculate an offset to apply later
     $Epoc   = 693901;
     $SecOff = timelocal( localtime(0) ) - timelocal( gmtime(0) );
     $Epoc += _daygm( gmtime(0) );
@@ -74,7 +74,7 @@ else {
     $Epoc = _daygm( gmtime(0) );
 }
 
-%Cheat = ();    # clear the cache as epoc has changed
+%Cheat = ();         # clear the cache as epoc has changed
 
 sub _daygm {
 


### PR DESCRIPTION
These versions do not munge years at all. They treat the year value that they
are given exactly as-is.

The docs encourage people to use this instead of the old versions.